### PR TITLE
Add Default implementation for GhostCell

### DIFF
--- a/src/ghost_cell.rs
+++ b/src/ghost_cell.rs
@@ -293,6 +293,12 @@ impl<'brand, T> GhostCell<'brand, T> {
     }
 }
 
+impl<'brand, T: Default> Default for GhostCell<'brand, T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
 impl<'brand, T> GhostCell<'brand, [T]> {
     /// Returns a slice of cell from a cell of slice.
     ///


### PR DESCRIPTION
A `Default` implementation makes `GhostCell` easier to use when embedded in some other data-structure.