### PR TITLE
Add CI via github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     env:
-      # Emit backtraces on panics.
-      RUST_BACKTRACE: 1
+      RUST_BACKTRACE: 1 # Emit backtraces on panics.
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -30,4 +29,4 @@ jobs:
           toolchain: stable
           profile: minimal
           components: clippy
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy -- -D warnings # Deny clippy warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+name: ci
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    env:
+      # Emit backtraces on panics.
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - run: cargo test --verbose --workspace
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy
+      - run: cargo clippy -- -D warnings

--- a/src/ghost_cell.rs
+++ b/src/ghost_cell.rs
@@ -43,6 +43,7 @@ impl<'brand> GhostToken<'brand> {
     ///
     /// assert_eq!(33, value);
     /// ```
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<R, F>(fun: F) -> R
     where
         for <'new_brand> F: FnOnce(GhostToken<'new_brand>) -> R


### PR DESCRIPTION
In response to this comment: https://github.com/matthieu-m/ghost-cell/pull/4#issuecomment-864388500

GH actions should start running by default for most repositories, [example here](https://github.com/mkatychev/ghost-cell/runs/3343800936?check_suite_focus=true)

* Added `cargo test` CI step
* Added `cargo clippy` CI step