### PR TITLE
Improve documentation & some minor formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["experimental", "aliasing", "borrowing"]
 categories = ["memory-management", "no-std"]
 
 [features]
-# Enables the use of unproven GhostCursor.
+# Enables the use of the unproven GhostCursor.
 experimental-ghost-cursor = []
 # Enables the use of unproven multiple mutable borrows.
 experimental-multiple-mutable-borrows = []

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 A novel safe and zero-cost borrow-checking paradigm from the
-[`GhostCell`](http://plv.mpi-sws.org/rustbelt/ghostcell/) paper.
+[`GhostCell`](https://plv.mpi-sws.org/rustbelt/ghostcell/) paper.
 
 
 #   Motivation
 
-A number of collections, such as linked-lists, binary-trees, or B-Trees are most easily implemented with aliasing
+A number of collections, such as linked lists, binary trees, or B-trees are most easily implemented with aliasing
 pointers.
 
 Traditionally, this means using run-time borrow-checking in order to still be able to mutate said structures, or using
 `unsafe` in the name of performance.
 
 By using _brands_, `GhostCell` separate the data from the permission to mutate it, and uses a unique `GhostToken` to
-model this permission, tied at compile-time to a number of said `GhostCell` via the _brand_.
+model this permission, tied at compile-time to a number of said `GhostCell`s via the _brand_.
 
 
 #   Safety
 
 In the GhostCell paper, Joshua Yanovski and his colleagues from MPI-SWS, Germany, formally demonstrate the safety of
 `GhostCell` using the separation logic they have developed as part of the
-[Rust Belt project](https://plv.mpi-sws.org/rustbelt/). I personally would trust them on this.
+[RustBelt project](https://plv.mpi-sws.org/rustbelt/). I personally would trust them on this.
 
 The official implementation can be found at https://gitlab.mpi-sws.org/FP/ghostcell/-/tree/master/ghostcell, along with
 examples. The current implementation will be upgraded soonish, now that I'm aware of it.
@@ -46,7 +46,7 @@ Tests:
 
 #   How to use?
 
-Let's start from a self-contained example:
+Let's start with a self-contained example:
 
 ```rust
 use ghost_cell::{GhostToken, GhostCell};
@@ -92,8 +92,8 @@ Using `borrow` or `borrow_mut` borrow _both_ the cell and the token.
 
 A `GhostCell` is a safe, zero-cost, cell. It allows aliasing with compile-time checked borrow-checking.
 
-Combined with [`StaticRc`](https://crates.io/crates/static-rc), it allows writing Doubly Linked Lists, Binary Trees and
-B-Trees with parent pointers, etc... in safe, stable, Rust.
+Combined with [`StaticRc`](https://crates.io/crates/static-rc), it allows writing doubly linked lists, binary trees and
+B-trees with parent pointers, etc... in safe, stable, Rust.
 
 
 #   Other Cells

--- a/src/ghost_borrow.rs
+++ b/src/ghost_borrow.rs
@@ -13,7 +13,7 @@ use crate::ghost_cell::*;
 pub trait GhostBorrow<'a, 'brand> {
     /// The references you get as a result.
     ///
-    /// For example, if Self is `(&'a GhostCell<'brand, T0>, &'a GhostCell<'brand, T1>)` then `Result` is
+    /// For example, if `Self` is `(&'a GhostCell<'brand, T0>, &'a GhostCell<'brand, T1>)` then `Result` is
     /// `(&'a T0, &'a T1)`.
     type Result;
 
@@ -45,7 +45,7 @@ impl<'a, 'brand, T> GhostBorrow<'a, 'brand> for &'a [GhostCell<'brand, T>] {
         //  Safety:
         //  -   Shared access to the `GhostToken` ensures shared access to the cells' content.
         //  -   `GhostCell` is `repr(transparent)`, hence `T` and `GhostCell<T>` have the same memory representation.
-       unsafe { mem::transmute::<Self, Self::Result>(self) }
+        unsafe { mem::transmute::<Self, Self::Result>(self) }
     }
 }
 

--- a/src/ghost_borrow_mut.rs
+++ b/src/ghost_borrow_mut.rs
@@ -1,4 +1,4 @@
-//! The `GhostBorrowMut` trait, which allows mutably borrowing multiple `GhostCell` simultaneously.
+//! The `GhostBorrowMut` trait, which allows mutably borrowing multiple `GhostCell`s simultaneously.
 //!
 //! This module implement the `GhostBorrowMut` trait for:
 //!
@@ -26,7 +26,7 @@ pub struct GhostAliasingError();
 
 /// A void struct. Used as the error case when The error case is impossible.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
-pub enum VoidError{}
+pub enum VoidError {}
 
 impl VoidError {
     /// Returns any type. Can't happen since `VoidError` can't be constructed.
@@ -56,14 +56,14 @@ impl From<VoidError> for GhostAliasingError {
 pub trait GhostBorrowMut<'a, 'brand> {
     /// The references you get as a result.
     ///
-    /// For example, if Self is `(&'a GhostCell<'brand, T0>, &'a GhostCell<'brand, T1>)` then `Result` is
+    /// For example, if `Self` is `(&'a GhostCell<'brand, T0>, &'a GhostCell<'brand, T1>)` then `Result` is
     /// `(&'a mut T0, &'a mut T1)`.
     type Result;
 
     /// The error case.
     ///
     /// Use a never type such as `!` or `VoidError` if an error is impossible, and `GhostAliasingError` otherwise.
-    type Error : Into<GhostAliasingError>;
+    type Error: Into<GhostAliasingError>;
 
     /// Borrows any number of `GhostCell`s mutably at the same time.
     ///

--- a/src/ghost_cell.rs
+++ b/src/ghost_cell.rs
@@ -1,6 +1,6 @@
-//! `GhostCell` and `GhostToken`, as per http://plv.mpi-sws.org/rustbelt/ghostcell/.
+//! `GhostCell` and `GhostToken`, as per <https://plv.mpi-sws.org/rustbelt/ghostcell/>.
 //!
-//! Reference implementation at https://gitlab.mpi-sws.org/FP/ghostcell/-/tree/master/ghostcell.
+//! Reference implementation at <https://gitlab.mpi-sws.org/FP/ghostcell/-/tree/master/ghostcell>.
 
 use core::{
     cell::UnsafeCell,
@@ -29,7 +29,7 @@ impl<'brand> GhostToken<'brand> {
     /// ```rust
     /// use ghost_cell::{GhostToken, GhostCell};
     ///
-    /// let n = 42;
+    /// let n = 12;
     ///
     /// let value = GhostToken::new(|mut token| {
     ///     let cell = GhostCell::new(42);
@@ -46,7 +46,7 @@ impl<'brand> GhostToken<'brand> {
     #[allow(clippy::new_ret_no_self)]
     pub fn new<R, F>(fun: F) -> R
     where
-        for <'new_brand> F: FnOnce(GhostToken<'new_brand>) -> R
+        for<'new_brand> F: FnOnce(GhostToken<'new_brand>) -> R,
     {
         let token = Self { _marker: InvariantLifetime::default() };
         fun(token)
@@ -59,12 +59,12 @@ unsafe impl<'brand> Send for GhostToken<'brand> {}
 /// A `GhostToken` is stateless, therefore it can safely be accessed from different threads.
 unsafe impl<'brand> Sync for GhostToken<'brand> {}
 
-/// Branded wrapper for the data structure's nodes, whose type is T.
+/// Branded wrapper for a value, whose type is `T`.
 ///
 /// A `GhostCell<'x, T>` owns an instance of type `T`:
 /// -   Unique access to the cell allows unimpeded access to the contained value.
 /// -   Shared access to the cell requires mediating access through the associated `GhostToken<'x, T>` which will
-///     enforce at compile-time the Aliasing XOR Mutability safety property.
+///     enforce at compile-time the aliasing XOR mutability safety property.
 #[repr(transparent)]
 pub struct GhostCell<'brand, T: ?Sized> {
     _marker: InvariantLifetime<'brand>,
@@ -72,7 +72,7 @@ pub struct GhostCell<'brand, T: ?Sized> {
 }
 
 impl<'brand, T> GhostCell<'brand, T> {
-    /// Wraps some data T into a GhostCell with brand `'brand` which associates it to one, and only one, `GhostToken`.
+    /// Wraps some `T` into a `GhostCell` with brand `'brand` which associates it to one, and only one, `GhostToken`.
     ///
     /// #   Example
     ///
@@ -89,10 +89,10 @@ impl<'brand, T> GhostCell<'brand, T> {
         let _marker = InvariantLifetime::default();
         let value = UnsafeCell::new(value);
 
-        Self { _marker, value, }
+        Self { _marker, value }
     }
 
-    /// Turns an owned GhostCell back into owned data.
+    /// Turns an owned `GhostCell` back into owned data.
     ///
     /// #   Example
     ///
@@ -109,14 +109,14 @@ impl<'brand, T> GhostCell<'brand, T> {
     /// ```
     pub fn into_inner(self) -> T { self.value.into_inner() }
 
-    /// Immutably borrows the GhostCell with the same-branded token.
+    /// Immutably borrows the `GhostCell` with the same-branded token.
     ///
     /// #   Example
     ///
     /// ```rust
     /// use ghost_cell::{GhostToken, GhostCell};
     ///
-    /// let n = 42;
+    /// let n = 12;
     ///
     /// let value = GhostToken::new(|mut token| {
     ///     let cell = GhostCell::new(42);
@@ -138,17 +138,17 @@ impl<'brand, T> GhostCell<'brand, T> {
         //  -   `self.value` therefore cannot be already borrowed mutably, as doing so requires calling either:
         //      -   `borrow_mut`, which would borrow the token mutably.
         //      -   `get_mut`, which would borrow the cell mutably.
-        unsafe{ &*self.value.get() }
+        unsafe { &*self.value.get() }
     }
 
-    /// Mutably borrows the GhostCell with the same-branded token.
+    /// Mutably borrows the `GhostCell` with the same-branded token.
     ///
     /// #   Example
     ///
     /// ```rust
     /// use ghost_cell::{GhostToken, GhostCell};
     ///
-    /// let n = 42;
+    /// let n = 12;
     ///
     /// let value = GhostToken::new(|mut token| {
     ///     let cell = GhostCell::new(42);
@@ -170,7 +170,7 @@ impl<'brand, T> GhostCell<'brand, T> {
         //  -   `self.value` therefore cannot already be borrowed, as doing so requires calling either:
         //      -   `borrow` or `borrow_mut`, which would borrow the token.
         //      -   `get_mut`, which would borrow the cell mutably.
-        unsafe{ &mut *self.value.get() }
+        unsafe { &mut *self.value.get() }
     }
 }
 
@@ -178,7 +178,7 @@ impl<'brand, T: ?Sized> GhostCell<'brand, T> {
     /// Returns a raw pointer to the contained value.
     pub const fn as_ptr(&self) -> *mut T { self.value.get() }
 
-    /// Turns a mutably borrowed GhostCell to mutably borrowed data.
+    /// Turns a mutably borrowed `GhostCell` into mutably borrowed data.
     ///
     /// `self` is mutably borrowed for the lifetime of the result, ensuring the absence of aliasing.
     ///
@@ -186,8 +186,6 @@ impl<'brand, T: ?Sized> GhostCell<'brand, T> {
     ///
     /// ```rust
     /// use ghost_cell::{GhostToken, GhostCell};
-    ///
-    /// let n = 42;
     ///
     /// let value = GhostToken::new(|mut token| {
     ///     let mut cell = GhostCell::new(42);
@@ -206,7 +204,7 @@ impl<'brand, T: ?Sized> GhostCell<'brand, T> {
         unsafe { mem::transmute(self) }
     }
 
-    /// Turns mutably borrowed data to a mutably borrowed GhostCell.
+    /// Turns mutably borrowed data into a mutably borrowed `GhostCell`.
     ///
     /// `t` is mutably borrowed for the lifetime of the result, ensuring the absence of aliasing.
     ///
@@ -215,7 +213,7 @@ impl<'brand, T: ?Sized> GhostCell<'brand, T> {
     /// ```rust
     /// use ghost_cell::{GhostToken, GhostCell};
     ///
-    /// let n = 42;
+    /// let n = 12;
     /// let mut value = 42;
     ///
     /// GhostToken::new(|mut token| {
@@ -236,7 +234,7 @@ impl<'brand, T: ?Sized> GhostCell<'brand, T> {
     }
 }
 
-//  Safe, convenience methods
+//  Safe convenience methods
 #[forbid(unsafe_code)]
 impl<'brand, T> GhostCell<'brand, T> {
     /// Returns the value, replacing it by the supplied one.
@@ -246,7 +244,7 @@ impl<'brand, T> GhostCell<'brand, T> {
     /// ```rust
     /// use ghost_cell::{GhostToken, GhostCell};
     ///
-    /// let n = 42;
+    /// let n = 12;
     ///
     /// let value = GhostToken::new(|mut token| {
     ///     let cell = GhostCell::new(42);
@@ -272,7 +270,7 @@ impl<'brand, T> GhostCell<'brand, T> {
     /// ```rust
     /// use ghost_cell::{GhostToken, GhostCell};
     ///
-    /// let n = 42;
+    /// let n = 12;
     ///
     /// let value = GhostToken::new(|mut token| {
     ///     let cell = GhostCell::new(42);
@@ -302,14 +300,14 @@ impl<'brand, T: Default> Default for GhostCell<'brand, T> {
 }
 
 impl<'brand, T> GhostCell<'brand, [T]> {
-    /// Returns a slice of cell from a cell of slice.
+    /// Returns a slice of cells from a cell containing a slice.
     ///
     /// #   Example
     ///
     /// ```rust
     /// use ghost_cell::{GhostToken, GhostCell};
     ///
-    /// let n = 42;
+    /// let n = 12;
     ///
     /// let value = GhostToken::new(|mut token| {
     ///     let mut vec: Vec<_> = (0..n).collect();
@@ -340,16 +338,17 @@ impl<'brand, T> From<T> for GhostCell<'brand, T> {
     fn from(t: T) -> Self { Self::new(t) }
 }
 
-/// A `GhostCell<'_, T>` owns a `T`, so cannot be sent across threads if `T` cannot.
+/// A `GhostCell<'_, T>` owns a `T`, so it cannot be sent across threads if `T` cannot.
 ///
 /// Conversely, a `GhostCell` does not add any state on top of `T`, so if `T` can be sent across threads, so can
 /// `GhostCell<'_, T>`
 unsafe impl<'brand, T: Send> Send for GhostCell<'brand, T> {}
 
-/// A `GhostCell<'_, T>` owns a `T`, so cannot be accessed from different threads if `T` cannot.
+/// A `GhostCell<'_, T>` owns a `T`, so it cannot be accessed from different threads if `T` cannot.
 ///
 /// Conversely, a `GhostCell` does not add any state on top of `T`, so if `T` can be accessed from different threads,
-/// so can `GhostCell<'_, T>`.
+/// so can `GhostCell<'_, T>`. `T` also needs to be sendable across threads,
+/// because a `T` can be extracted from a `&GhostCell<'brand, T>` via [`GhostCell::replace`].
 unsafe impl<'brand, T: Send + Sync> Sync for GhostCell<'brand, T> {}
 
 //

--- a/src/ghost_cursor.rs
+++ b/src/ghost_cursor.rs
@@ -17,7 +17,7 @@
 //! This is the crux of the issue, and the most likely place for unsoundness in the whole scheme.
 //!
 //! Let us start by a broken example to better understand what we are looking for. Let us imagine a simple doubly linked
-//! list data-structure where each node has an optional previous and next fields to point to the previous and next nodes
+//! list data structure where each node has an optional previous and next field to point to the previous and next node,
 //! respectively.
 //!
 //! Imagine the following set-up with 2 nodes `a` and `b`:
@@ -27,7 +27,7 @@
 //!
 //! Any method which allows both obtaining a reference to `b` and simultaneously a mutable reference to `a` is unsound,
 //! for owning a mutable reference to `a` allows setting both of its `prev` and `next` fields to `None`, dropping `b`,
-//! and of course retaining a reference to a dropped element is opening the door to Undefined Behavior.
+//! and of course retaining a reference to a dropped element is opening the door to undefined behavior.
 //!
 //! Hence, the very stringent invariant that the `GhostCursor` must enforce is that apart from the currently mutable
 //! element, no reference to other elements with no _separate_ anchoring ownership paths to the stack can be observed.
@@ -54,7 +54,7 @@ impl<'a, 'brand, T> GhostCursor<'a, 'brand, T> {
     pub fn new(token: &'a mut GhostToken<'brand>, cell: Option<&'a GhostCell<'brand, T>>) -> Self {
         let token = NonNull::from(token);
 
-        Self { token, cell, }
+        Self { token, cell }
     }
 
     /// Returns a mutable reference to the current element, if any.
@@ -116,7 +116,7 @@ impl<'a, 'brand, T> GhostCursor<'a, 'brand, T> {
     /// ```
     pub fn borrow(&self) -> Option<&T> {
         //  Safety:
-        //  -   Borrows `self`, therefore ensuring that no mutably borrow of the token exists.
+        //  -   Borrows `self`, therefore ensuring that no mutable borrow of the token exists.
         //  -   Restricts the lifetime of `token` to that of `self`.
         let token = unsafe { as_ref(self.token) };
 
@@ -144,7 +144,7 @@ impl<'a, 'brand, T> GhostCursor<'a, 'brand, T> {
     /// ```
     pub fn borrow_mut(&mut self) -> Option<&mut T> {
         //  Safety:
-        //  -   Borrows `self` mutably, therefore ensuring that no borrow of the token exists.
+        //  -   Borrows `self` mutably, therefore ensuring that no other borrow of the token exists.
         //  -   Restricts the lifetime of `token` to that of `self.`
         let token = unsafe { as_mut(self.token) };
 
@@ -157,7 +157,7 @@ impl<'a, 'brand, T> GhostCursor<'a, 'brand, T> {
     /// -   There is no current cell.
     /// -   `fun` returns no cell.
     ///
-    /// In case of error, the current cell is not modified.
+    /// In case of an error, the current cell is not modified.
     ///
     /// #   Example
     ///
@@ -205,7 +205,7 @@ impl<'a, 'brand, T> GhostCursor<'a, 'brand, T> {
     /// -   There is no current cell.
     /// -   `fun` returns no cell.
     ///
-    /// In case of error, the current cursor is returned.
+    /// In case of an error, the current cursor is returned.
     ///
     /// #   Example
     ///
@@ -252,7 +252,7 @@ impl<'a, 'brand, T> GhostCursor<'a, 'brand, T> {
         let cell = self.cell.ok_or(())?;
         let cell = fun(cell.borrow(token_mut)).ok_or(())?;
 
-        Ok(GhostCursor { token: self.token, cell: Some(cell), })
+        Ok(GhostCursor { token: self.token, cell: Some(cell) })
     }
 }
 

--- a/src/ghost_cursor.rs
+++ b/src/ghost_cursor.rs
@@ -17,7 +17,7 @@
 //! This is the crux of the issue, and the most likely place for unsoundness in the whole scheme.
 //!
 //! Let us start by a broken example to better understand what we are looking for. Let us imagine a simple doubly linked
-//! list data structure where each node has an optional previous and next field to point to the previous and next node,
+//! list data structure where each node has two optional fields, a previous and a next field, to point to the previous and next node,
 //! respectively.
 //!
 //! Imagine the following set-up with 2 nodes `a` and `b`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 //! This library provides an implementation of `GhostCell` and its `GhostToken` as per
-//! http://plv.mpi-sws.org/rustbelt/ghostcell/ as well as some extensions.
+//! <https://plv.mpi-sws.org/rustbelt/ghostcell/> as well as some extensions.
 //!
 //! #   Safety
 //!
-//! The actual implementation of `GhostCell` is found at https://gitlab.mpi-sws.org/FP/ghostcell/-/tree/master/ghostcell
+//! The actual implementation of `GhostCell` is found at <https://gitlab.mpi-sws.org/FP/ghostcell/-/tree/master/ghostcell>
 //! and has been proven safe. I have carefully checked that this implementation faithfully reproduces the safety
 //! guarantees.
 //!
@@ -50,7 +50,7 @@ pub use self::ghost_borrow::GhostBorrow;
 pub mod ghost_borrow_mut;
 
 #[cfg(feature = "experimental-multiple-mutable-borrows")]
-pub use self::ghost_borrow_mut::{GhostBorrowMut, GhostAliasingError, VoidError};
+pub use self::ghost_borrow_mut::{GhostAliasingError, GhostBorrowMut, VoidError};
 
 #[cfg(feature = "experimental-ghost-cursor")]
 pub mod ghost_cursor;


### PR DESCRIPTION
I also changed the `let n = 42;` in the examples to `let n = 12;`, because the examples already use `42` as a value, so I think it would be confusing to use 42 for two different things.