### PR TITLE
Fix CI `miri` job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,4 +49,4 @@ jobs:
           rustup toolchain install nightly --component miri
           rustup override set nightly
           cargo miri setup
-      - run: cargo miri test all-features --verbose
+      - run: cargo miri test --all-features --verbose


### PR DESCRIPTION
I just noticed that I wrote `cargo miri test all-features` instead of `cargo miri test --all-features` in #10, causing no tests to be run with Miri, sorry for that.