### PR TITLE
Use `?Sized` wherever possible

### DIFF
--- a/src/ghost_borrow.rs
+++ b/src/ghost_borrow.rs
@@ -62,7 +62,7 @@ impl<'a, 'brand, T, const N: usize> GhostBorrow<'a, 'brand> for &'a [GhostCell<'
 
 macro_rules! generate_public_instance {
     ( $($name:ident),* ; $($type_letter:ident),* ) => {
-        impl<'a, 'brand, $($type_letter,)*> GhostBorrow<'a, 'brand> for
+        impl<'a, 'brand, $($type_letter: ?Sized,)*> GhostBorrow<'a, 'brand> for
                 ( $(&'a GhostCell<'brand, $type_letter>, )* )
         {
             type Result = ( $(&'a $type_letter, )* );

--- a/src/ghost_borrow_mut.rs
+++ b/src/ghost_borrow_mut.rs
@@ -149,7 +149,7 @@ impl<'a, 'brand, T, const N: usize> GhostBorrowMut<'a, 'brand> for &'a [GhostCel
 
 macro_rules! generate_public_instance {
     ( $($name:ident),* ; $($type_letter:ident),* ) => {
-        impl<'a, 'brand, $($type_letter,)*> GhostBorrowMut<'a, 'brand> for
+        impl<'a, 'brand, $($type_letter: ?Sized,)*> GhostBorrowMut<'a, 'brand> for
                 ( $(&'a GhostCell<'brand, $type_letter>, )* )
         {
             type Result = ( $(&'a mut $type_letter, )* );

--- a/src/ghost_cell.rs
+++ b/src/ghost_cell.rs
@@ -108,7 +108,9 @@ impl<'brand, T> GhostCell<'brand, T> {
     /// assert_eq!(42, value);
     /// ```
     pub fn into_inner(self) -> T { self.value.into_inner() }
+}
 
+impl<'brand, T: ?Sized> GhostCell<'brand, T> {
     /// Immutably borrows the `GhostCell` with the same-branded token.
     ///
     /// #   Example
@@ -172,9 +174,7 @@ impl<'brand, T> GhostCell<'brand, T> {
         //      -   `get_mut`, which would borrow the cell mutably.
         unsafe { &mut *self.value.get() }
     }
-}
 
-impl<'brand, T: ?Sized> GhostCell<'brand, T> {
     /// Returns a raw pointer to the contained value.
     pub const fn as_ptr(&self) -> *mut T { self.value.get() }
 
@@ -342,14 +342,14 @@ impl<'brand, T> From<T> for GhostCell<'brand, T> {
 ///
 /// Conversely, a `GhostCell` does not add any state on top of `T`, so if `T` can be sent across threads, so can
 /// `GhostCell<'_, T>`
-unsafe impl<'brand, T: Send> Send for GhostCell<'brand, T> {}
+unsafe impl<'brand, T: ?Sized + Send> Send for GhostCell<'brand, T> {}
 
 /// A `GhostCell<'_, T>` owns a `T`, so it cannot be accessed from different threads if `T` cannot.
 ///
 /// Conversely, a `GhostCell` does not add any state on top of `T`, so if `T` can be accessed from different threads,
 /// so can `GhostCell<'_, T>`. `T` also needs to be sendable across threads,
 /// because a `T` can be extracted from a `&GhostCell<'brand, T>` via [`GhostCell::replace`].
-unsafe impl<'brand, T: Send + Sync> Sync for GhostCell<'brand, T> {}
+unsafe impl<'brand, T: ?Sized + Send + Sync> Sync for GhostCell<'brand, T> {}
 
 //
 //  Implementation

--- a/src/ghost_cursor.rs
+++ b/src/ghost_cursor.rs
@@ -44,12 +44,12 @@ use core::ptr::NonNull;
 use super::{GhostCell, GhostToken};
 
 /// A `GhostCursor`, to navigate across a web of `GhostCell`s.
-pub struct GhostCursor<'a, 'brand, T> {
+pub struct GhostCursor<'a, 'brand, T: ?Sized> {
     token: NonNull<GhostToken<'brand>>,
     cell: Option<&'a GhostCell<'brand, T>>,
 }
 
-impl<'a, 'brand, T> GhostCursor<'a, 'brand, T> {
+impl<'a, 'brand, T: ?Sized> GhostCursor<'a, 'brand, T> {
     /// Creates a new instance of the cursor.
     pub fn new(token: &'a mut GhostToken<'brand>, cell: Option<&'a GhostCell<'brand, T>>) -> Self {
         let token = NonNull::from(token);
@@ -261,11 +261,11 @@ impl<'a, 'brand, T> GhostCursor<'a, 'brand, T> {
 //  Implementation
 //
 
-unsafe fn as_ref<'a, T>(ptr: NonNull<T>) -> &'a T {
+unsafe fn as_ref<'a, T: ?Sized>(ptr: NonNull<T>) -> &'a T {
     &*ptr.as_ptr()
 }
 
-unsafe fn as_mut<'a, T>(ptr: NonNull<T>) -> &'a mut T {
+unsafe fn as_mut<'a, T: ?Sized>(ptr: NonNull<T>) -> &'a mut T {
     &mut *ptr.as_ptr()
 }
 


### PR DESCRIPTION
I found some places where `?Sized` could be used (namely `GhostCell::{borrow,borrow_mut}`).