### PR TITLE
Even more `?Sized` bounds

### DIFF
--- a/src/ghost_borrow.rs
+++ b/src/ghost_borrow.rs
@@ -73,10 +73,20 @@ impl<'a, 'brand, T: ?Sized, const N: usize> GhostBorrow<'a, 'brand> for [&'a Gho
     }
 }
 
+macro_rules! last {
+    () => {};
+    ($head:ident $(,)?) => {
+        $head
+    };
+    ($head:ident, $($tail:ident),+ $(,)?) => {
+        last!($($tail),+)
+    };
+}
+
 macro_rules! generate_public_instance {
     ( $($name:ident),* ; $($type_letter:ident),* ) => {
-        impl<'a, 'brand, $($type_letter: ?Sized,)*> GhostBorrow<'a, 'brand> for
-                ( $(&'a GhostCell<'brand, $type_letter>, )* )
+        impl<'a, 'brand, $($type_letter: ?Sized,)*> GhostBorrow<'a, 'brand>
+            for ( $(&'a GhostCell<'brand, $type_letter>, )* )
         {
             type Result = ( $(&'a $type_letter, )* );
 
@@ -87,8 +97,10 @@ macro_rules! generate_public_instance {
             }
         }
 
-        impl<'a, 'brand, $($type_letter,)*> GhostBorrow<'a, 'brand> for
-                &'a ( $(GhostCell<'brand, $type_letter>, )* )
+        impl<'a, 'brand, $($type_letter,)*> GhostBorrow<'a, 'brand>
+            for &'a ( $(GhostCell<'brand, $type_letter>, )* )
+        where
+            last!( $($type_letter),* ): ?Sized
         {
             type Result = &'a ( $($type_letter, )* );
 

--- a/src/ghost_borrow_mut.rs
+++ b/src/ghost_borrow_mut.rs
@@ -177,11 +177,20 @@ impl<'a, 'brand, T, const N: usize> GhostBorrowMut<'a, 'brand> for [&'a GhostCel
     }
 }
 
+macro_rules! last {
+    () => {};
+    ($head:ident $(,)?) => {
+        $head
+    };
+    ($head:ident, $($tail:ident),+ $(,)?) => {
+        last!($($tail),+)
+    };
+}
 
 macro_rules! generate_public_instance {
     ( $($name:ident),* ; $($type_letter:ident),* ) => {
-        impl<'a, 'brand, $($type_letter,)*> GhostBorrowMut<'a, 'brand> for
-                ( $(&'a GhostCell<'brand, $type_letter>, )* )
+        impl<'a, 'brand, $($type_letter,)*> GhostBorrowMut<'a, 'brand>
+            for ( $(&'a GhostCell<'brand, $type_letter>, )* )
         {
             type Result = ( $(&'a mut $type_letter, )* );
             type Error = GhostAliasingError;
@@ -207,8 +216,10 @@ macro_rules! generate_public_instance {
             }
         }
 
-        impl<'a, 'brand, $($type_letter,)*> GhostBorrowMut<'a, 'brand> for
-                &'a ( $(GhostCell<'brand, $type_letter>, )* )
+        impl<'a, 'brand, $($type_letter,)*> GhostBorrowMut<'a, 'brand>
+            for &'a ( $(GhostCell<'brand, $type_letter>, )* )
+        where
+            last!( $($type_letter),* ): ?Sized
         {
             type Result = &'a mut ( $($type_letter, )* );
             type Error = VoidError;


### PR DESCRIPTION
Overview:
- `GhostBorrow`/`GhostBorrowMut` for `&(GhostCell<T>, ...)`: The last type is `?Sized`.
  - The extra macro I wrote to help with this is duplicated between the two modules since it's really small. I can move it to a new module if needed, though.
- `GhostBorrowMut` for `(&GhostCell<T>, ...)`: Each type is `?Sized`.
  - Didn't require any other changes.
- `GhostBorrowMut` for `[&GhostCell<T>; N]`: `T` is `?Sized`.
  - I think I've found a solution to the problems discussed in [your previous comment](https://github.com/matthieu-m/ghost-cell/pull/16#discussion_r884114694).
  - I made `check_distinct` generic over a type `T` and made it take `[*const T; N]` instead of `[*const (); N]`.
    Each pointer is cast to `*const ()` during comparison (I made sure and checked, and std recommends this for by-address equality of fat pointers; [see the last example here](https://doc.rust-lang.org/stable/std/ptr/fn.eq.html#examples)).
    `[&GhostCell<T>; N]` and `[*const T; N]` definitely have the same layout, so no strange pointer casting issues here.
  - It doesn't require the pointer metadata API!
- I made a few basic positive and negative tests.