### PR TITLE
WIP Fix GhostBorrowMut interaction with slices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,10 @@
 
 //  Generic features.
 #![cfg_attr(not(test), no_std)]
+#![cfg_attr(feature = "experimental-multiple-mutable-borrows", feature(specialization))]
 
 //  Lints.
+#![cfg_attr(feature = "experimental-multiple-mutable-borrows", allow(incomplete_features))]
 #![deny(missing_docs)]
 
 pub mod ghost_cell;


### PR DESCRIPTION
* Changes:

- Switch check_distinct to detect overlap between slices, and overlap between single values and slices.
- Add specialization feature, when using ghost-borrow-mut, to allow the above.

* Motivation:

There is a soundness issue as exposed by @noamtashma in #23, since the usecase is useful, it seems better to fix the issue.

* Limitations:

- Performance may be lackluster.
- Specialization is an unstable feature with no clear path towards stabilization.
- No test for slice vs slice could be created, it is not clear whether obtaining two independent GhostCells with overlapping slices is even possible in the first place.
- Tests of check_distinct, in general, are lackluster.